### PR TITLE
Fix Resources.resx for Linux

### DIFF
--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -119,6 +119,6 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="screen_sleep_glossy" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\assets\screen_sleep_glossy.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>..\Assets\screen_sleep_glossy.ico;System.Drawing.Icon, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>


### PR DESCRIPTION
Capitalise `assets` to fix compile error caused by building program on Linux. Useful because a CI Pipeline on Linux may be desired in the future.